### PR TITLE
add the deviceNumber of the wall-mounted thermostat

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function RademacherHomePilot(log, config, api) {
                             }
                         }
                         // thermostat
-                        else if(["35003064"].includes(data.deviceNumber))
+                        else if(["35003064","32501812_A"].includes(data.deviceNumber))
                         {
                             if (accessory === undefined) {
                                 self.addThermostatAccessory(data);


### PR DESCRIPTION
Product page:
https://www.rademacher.de/en/smart-home/produkte/duofern-raumthermostat-9485?productID=32501812

The APIs of this and the previously supported thermostat are the same (at least as far as implemented functionality goes).