### PR TITLE
Bugfix switch

### DIFF
--- a/accessories/RademacherSwitchAccessory.js
+++ b/accessories/RademacherSwitchAccessory.js
@@ -31,6 +31,7 @@ RademacherSwitchAccessory.prototype.getCurrentState = function(callback) {
         }
         const position=data?data.statusesMap.Position:0;
         self.currentState=position==100?true:false;
+        self.lastState = self.currentState;
         if (self.debug) self.log("%s [%s] - getCurrentState(): position=%s, state=%s", self.accessory.displayName, self.sw.did, position, self.currentState);
         self.service.getCharacteristic(global.Characteristic.On).updateValue(self.currentState);
     });


### PR DESCRIPTION
When switching the hardware switch the internal status was not updated so the software switch does not switch after manual action (and switches back to the last state). Workaround was to switch it fast off and on and then off (or on - off - on). This pull request fixes the bug.