### PR TITLE
Fix crash when a cached accessory is missing a service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.0.2
+### fix crash when a cached accessory is missing a service
+
 ## 1.0.1
 ### fixed typo
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-rademacher-homepilot",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "rademacher homepilot plugin for homebridge: https://github.com/bombadiltom/homebridge-rademacher-homepilot",
   "license": "MIT",
   "keywords": [

--- a/src/accessories/RademacherAccessory.ts
+++ b/src/accessories/RademacherAccessory.ts
@@ -1,4 +1,4 @@
-import type { Logging, PlatformAccessory } from 'homebridge' with { 'resolution-mode': 'import' };
+import type { Logging, PlatformAccessory, Service, WithUUID } from 'homebridge' with { 'resolution-mode': 'import' };
 import { hap } from '../hap';
 import type { RademacherHomePilotSession } from '../RademacherHomePilotSession';
 import type { HomePilotItem } from '../types';
@@ -42,6 +42,16 @@ export class RademacherAccessory {
         this.debug = debug;
         this.session = session;
         this.did = data.did;
+    }
+
+    // A cached accessory restored from homebridge's persisted accessories.json can be
+    // missing a service (e.g. it was cached by an older plugin version, or the HomePilot
+    // gateway reassigned the did to a different device type). Rather than crashing with
+    // "Cannot read properties of undefined (reading 'getCharacteristic')" - which, thrown
+    // from inside the devices-list GET handler, silently aborts processing of every
+    // remaining device in that batch - self-heal by adding the missing service.
+    protected getOrAddService<S extends WithUUID<typeof Service> & (new (displayName?: string, subtype?: string) => Service)>(serviceConstructor: S, name: string): Service {
+        return this.accessory.getService(serviceConstructor) ?? this.accessory.addService(new serviceConstructor(name));
     }
 
     getDevice(callback: DeviceCallback): void {

--- a/src/accessories/RademacherBlindsAccessory.ts
+++ b/src/accessories/RademacherBlindsAccessory.ts
@@ -28,7 +28,7 @@ export class RademacherBlindsAccessory extends RademacherAccessory {
         this.lastPosition = this.inverted ? tools.reversePercentage(position) : position;
         this.currentTargetPosition = this.lastPosition;
         this.obstructionDetected = false;
-        this.service = this.accessory.getService(hap.Service.WindowCovering)!;
+        this.service = this.getOrAddService(hap.Service.WindowCovering, this.accessory.displayName);
         this.service
             .getCharacteristic(hap.Characteristic.CurrentPosition)
             .setValue(this.currentTargetPosition)

--- a/src/accessories/RademacherDimmerAccessory.ts
+++ b/src/accessories/RademacherDimmerAccessory.ts
@@ -30,7 +30,7 @@ export class RademacherDimmerAccessory extends RademacherAccessory {
         this.currentBrightness = this.lastBrightness;
         this.currentStatus = position > 0;
         this.lastStatus = this.currentStatus;
-        this.service = this.accessory.getService(hap.Service.Lightbulb)!;
+        this.service = this.getOrAddService(hap.Service.Lightbulb, this.accessory.displayName);
         this.service.getCharacteristic(hap.Characteristic.On)
             .on('get', this.getStatus.bind(this))
             .on('set', this.setStatus.bind(this));

--- a/src/accessories/RademacherDoorSensorAccessory.ts
+++ b/src/accessories/RademacherDoorSensorAccessory.ts
@@ -18,14 +18,14 @@ export class RademacherDoorSensorAccessory extends RademacherAccessory {
         this.services = [];
         // contact sensor
         this.currentState = this.sensor.readings?.contact_state !== 'closed';
-        const contactsensorService = this.accessory.getService(hap.Service.ContactSensor)!;
+        const contactsensorService = this.getOrAddService(hap.Service.ContactSensor, this.accessory.displayName);
         contactsensorService.getCharacteristic(hap.Characteristic.ContactSensorState)
             .setValue(this.currentState)
             .on('get', this.getCurrentDoorState.bind(this));
         this.services.push(contactsensorService);
         // battery
         this.currentBatteryLevel = this.sensor.batteryStatus ?? 0;
-        const batteryService = this.accessory.getService(hap.Service.Battery)!;
+        const batteryService = this.getOrAddService(hap.Service.Battery, this.accessory.displayName);
         batteryService.getCharacteristic(hap.Characteristic.BatteryLevel)
             .setValue(this.currentBatteryLevel)
             .on('get', this.getCurrentBatteryLevel.bind(this));

--- a/src/accessories/RademacherEnvironmentSensorAccessory.ts
+++ b/src/accessories/RademacherEnvironmentSensorAccessory.ts
@@ -19,7 +19,7 @@ export class RademacherEnvironmentSensorAccessory extends RademacherAccessory {
         this.services = [];
         // temperature sensor
         this.currentTemperature = sensor.readings?.temperature_primary ?? 0;
-        const temperatureService = this.accessory.getService(hap.Service.TemperatureSensor)!;
+        const temperatureService = this.getOrAddService(hap.Service.TemperatureSensor, this.accessory.displayName);
         temperatureService.getCharacteristic(hap.Characteristic.CurrentTemperature)
             .setProps({ minValue: -30.0, maxValue: 80.0 })
             .setValue(this.currentTemperature)
@@ -27,7 +27,7 @@ export class RademacherEnvironmentSensorAccessory extends RademacherAccessory {
         this.services.push(temperatureService);
         // light sensor
         this.currentAmbientLightLevel = sensor.readings?.sun_brightness ?? 0;
-        const lightService = this.accessory.getService(hap.Service.LightSensor)!;
+        const lightService = this.getOrAddService(hap.Service.LightSensor, this.accessory.displayName);
         lightService.getCharacteristic(hap.Characteristic.CurrentAmbientLightLevel)
             .setProps({ minValue: 0, maxValue: 150000 })
             .setValue(this.currentAmbientLightLevel)
@@ -35,7 +35,7 @@ export class RademacherEnvironmentSensorAccessory extends RademacherAccessory {
         this.services.push(lightService);
         // Rain sensor
         this.currentRainState = !!this.sensor.readings?.rain_detected;
-        const rainsensorService = this.accessory.getService(hap.Service.ContactSensor)!;
+        const rainsensorService = this.getOrAddService(hap.Service.ContactSensor, this.accessory.displayName);
         rainsensorService.getCharacteristic(hap.Characteristic.ContactSensorState)
             .setValue(this.currentRainState)
             .on('get', this.getCurrentRainState.bind(this));

--- a/src/accessories/RademacherLockAccessory.ts
+++ b/src/accessories/RademacherLockAccessory.ts
@@ -14,7 +14,7 @@ export class RademacherLockAccessory extends RademacherAccessory {
     constructor(log: Logging, debug: boolean, accessory: PlatformAccessory, lock: HomePilotItem, session: RademacherHomePilotSession) {
         super(log, debug, accessory, lock, session);
         this.lock = lock;
-        this.lockservice = accessory.getService(hap.Service.LockMechanism)!;
+        this.lockservice = this.getOrAddService(hap.Service.LockMechanism, accessory.displayName);
 
         this.currentState = lock.statusesMap?.Position === 0
             ? hap.Characteristic.LockCurrentState.SECURED

--- a/src/accessories/RademacherSceneAccessory.ts
+++ b/src/accessories/RademacherSceneAccessory.ts
@@ -17,7 +17,7 @@ export class RademacherSceneAccessory extends RademacherAccessory {
 
         this.debug = true;
 
-        this.service = this.accessory.getService(hap.Service.Switch)!;
+        this.service = this.getOrAddService(hap.Service.Switch, this.accessory.displayName);
 
         this.service
             .getCharacteristic(hap.Characteristic.On).setValue(false)

--- a/src/accessories/RademacherSmokeAlarmAccessory.ts
+++ b/src/accessories/RademacherSmokeAlarmAccessory.ts
@@ -18,14 +18,14 @@ export class RademacherSmokeAlarmAccessory extends RademacherAccessory {
         this.services = [];
         // smoke
         this.smokeDetected = !!this.sensor.readings?.smoke_detected;
-        const smokesensorService = this.accessory.getService(hap.Service.SmokeSensor)!;
+        const smokesensorService = this.getOrAddService(hap.Service.SmokeSensor, this.accessory.displayName);
         smokesensorService.getCharacteristic(hap.Characteristic.SmokeDetected)
             .setValue(this.smokeDetected)
             .on('get', this.getSmokeDetected.bind(this));
         this.services.push(smokesensorService);
         // battery
         this.currentBatteryLevel = this.sensor.batteryStatus ?? 0;
-        const batteryService = this.accessory.getService(hap.Service.Battery)!;
+        const batteryService = this.getOrAddService(hap.Service.Battery, this.accessory.displayName);
         batteryService.getCharacteristic(hap.Characteristic.BatteryLevel)
             .setValue(this.currentBatteryLevel)
             .on('get', this.getCurrentBatteryLevel.bind(this));

--- a/src/accessories/RademacherSunSensorAccessory.ts
+++ b/src/accessories/RademacherSunSensorAccessory.ts
@@ -17,14 +17,14 @@ export class RademacherSunSensorAccessory extends RademacherAccessory {
         this.services = [];
         // Light sensor
         this.currentSunState = this.sensor.readings?.sun_detected ? 100000 : 0.0001;
-        const lightSensorService = this.accessory.getService(hap.Service.LightSensor)!;
+        const lightSensorService = this.getOrAddService(hap.Service.LightSensor, this.accessory.displayName);
         lightSensorService.getCharacteristic(hap.Characteristic.CurrentAmbientLightLevel)
             .setProps({ minValue: 0.0001, maxValue: 100000 })
             .setValue(this.currentSunState)
             .on('get', this.getCurrentSunState.bind(this));
         this.services.push(lightSensorService);
         // Switch (ambient light level characteristic of light sensor cannot yet be used as trigger in HomeKit)
-        const switchService = this.accessory.getService(hap.Service.Switch)!;
+        const switchService = this.getOrAddService(hap.Service.Switch, this.accessory.displayName);
         switchService.getCharacteristic(hap.Characteristic.On)
             .setValue(!!this.sensor.readings?.sun_detected);
         this.services.push(switchService);

--- a/src/accessories/RademacherSwitchAccessory.ts
+++ b/src/accessories/RademacherSwitchAccessory.ts
@@ -20,7 +20,7 @@ export class RademacherSwitchAccessory extends RademacherAccessory {
         if (this.debug) {
             this.log('%s [%s] - RademacherSwitchAccessory(): initial state=%s', this.accessory.displayName, this.sw.did, this.currentState);
         }
-        this.service = this.accessory.getService(hap.Service.Switch)!;
+        this.service = this.getOrAddService(hap.Service.Switch, this.accessory.displayName);
         this.service
             .getCharacteristic(hap.Characteristic.On)
             .setValue(this.currentState)

--- a/src/accessories/RademacherTemperatureSensorAccessory.ts
+++ b/src/accessories/RademacherTemperatureSensorAccessory.ts
@@ -17,7 +17,7 @@ export class RademacherTemperatureSensorAccessory extends RademacherAccessory {
         this.sensor = sensor;
         this.currentTemperature = sensor.readings?.temperature_primary ?? 0;
 
-        this.service = this.accessory.getService(hap.Service.TemperatureSensor)!;
+        this.service = this.getOrAddService(hap.Service.TemperatureSensor, this.accessory.displayName);
         this.service.getCharacteristic(hap.Characteristic.CurrentTemperature)
             .setProps({ minValue: -30.0, maxValue: 80.0 })
             .setValue(this.currentTemperature)

--- a/src/accessories/RademacherThermostatAccessory.ts
+++ b/src/accessories/RademacherThermostatAccessory.ts
@@ -31,7 +31,7 @@ export class RademacherThermostatAccessory extends RademacherAccessory {
             this.currentState = hap.Characteristic.CurrentHeatingCoolingState.HEAT;
         }
 
-        this.service = this.accessory.getService(hap.Service.Thermostat)!;
+        this.service = this.getOrAddService(hap.Service.Thermostat, this.accessory.displayName);
 
         this.service.getCharacteristic(hap.Characteristic.CurrentHeatingCoolingState)
             .setValue(this.currentState)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -123,97 +123,105 @@ export class RademacherHomePilot implements DynamicPlatformPlugin {
         }
         if (body.devices) {
             body.devices.filter(data => this.didFilter(config, data)).forEach((data) => {
-                const uuid = hap.uuid.generate('did' + data.did);
-                const accessory = this.accessories[uuid];
-
-                // blinds
-                if (BLINDS_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_blinds')) {
-                        if (accessory === undefined) {
-                            this.addBlindsAccessory(data);
-                        } else {
-                            this.log('blinds are online: %s [%s]', this.displayName(accessory), data.did);
-                            this.accessories[uuid] = new RademacherBlindsAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                        }
-                    } else {
-                        this.log('blinds found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // dimmer
-                else if (DIMMER_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_dimmer')) {
-                        if (accessory === undefined) {
-                            this.addDimmerAccessory(data);
-                        } else {
-                            this.log('dimmer is online: %s [%s]', this.displayName(accessory), data.did);
-                            this.accessories[uuid] = new RademacherDimmerAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                        }
-                    } else {
-                        this.log('dimmer found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // thermostat
-                else if (THERMOSTAT_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_thermostat')) {
-                        if (accessory === undefined) {
-                            this.addThermostatAccessory(data);
-                        } else {
-                            this.log('thermostat is online: %s [%s]', this.displayName(accessory), data.did);
-                            this.accessories[uuid] = new RademacherThermostatAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                        }
-                    } else {
-                        this.log('thermostat found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // lock/switch
-                else if (LOCK_SWITCH_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_lock_switch')) {
-                        // icon = "Schließkontakt" ? => lock
-                        if (data.iconSet?.k.includes('iconset27')) {
-                            if (accessory === undefined) {
-                                this.addLockAccessory(data);
-                            } else {
-                                this.log('lock is online: %s [%s]', this.displayName(accessory), data.did);
-                                this.accessories[uuid] = new RademacherLockAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                            }
-                        } else {
-                            if (accessory === undefined) {
-                                this.addSwitchAccessory(data);
-                            } else {
-                                this.log('switch is online: %s [%s]', this.displayName(accessory), data.did);
-                                this.accessories[uuid] = new RademacherSwitchAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                            }
-                        }
-                    } else {
-                        this.log('lock/switch found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // environment sensor
-                else if (ENVIRONMENT_SENSOR_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_environment_sensor')) {
-                        this.addEnvironmentSensorAccessory(accessory, data);
-                    } else {
-                        this.log('environment sensor found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // sun sensor
-                else if (SUN_SENSOR_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_sun_sensor')) {
-                        this.addSunSensorAccessory(accessory, data);
-                    } else {
-                        this.log('sun sensor found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // unknown
-                else {
-                    this.log('Unknown product: %s', data.deviceNumber);
-                    if (this.debug) {
-                        this.log(String(data));
-                    }
+                try {
+                    this.handleActuator(config, data);
+                } catch (err) {
+                    this.log('Error processing device %s [%s]: %s', data.name, data.did, err);
                 }
             });
         } else {
             this.log('No devices found in %s', body);
+        }
+    }
+
+    private handleActuator(config: PlatformConfig, data: HomePilotItem): void {
+        const uuid = hap.uuid.generate('did' + data.did);
+        const accessory = this.accessories[uuid];
+
+        // blinds
+        if (BLINDS_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_blinds')) {
+                if (accessory === undefined) {
+                    this.addBlindsAccessory(data);
+                } else {
+                    this.log('blinds are online: %s [%s]', this.displayName(accessory), data.did);
+                    this.accessories[uuid] = new RademacherBlindsAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                }
+            } else {
+                this.log('blinds found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // dimmer
+        else if (DIMMER_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_dimmer')) {
+                if (accessory === undefined) {
+                    this.addDimmerAccessory(data);
+                } else {
+                    this.log('dimmer is online: %s [%s]', this.displayName(accessory), data.did);
+                    this.accessories[uuid] = new RademacherDimmerAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                }
+            } else {
+                this.log('dimmer found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // thermostat
+        else if (THERMOSTAT_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_thermostat')) {
+                if (accessory === undefined) {
+                    this.addThermostatAccessory(data);
+                } else {
+                    this.log('thermostat is online: %s [%s]', this.displayName(accessory), data.did);
+                    this.accessories[uuid] = new RademacherThermostatAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                }
+            } else {
+                this.log('thermostat found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // lock/switch
+        else if (LOCK_SWITCH_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_lock_switch')) {
+                // icon = "Schließkontakt" ? => lock
+                if (data.iconSet?.k.includes('iconset27')) {
+                    if (accessory === undefined) {
+                        this.addLockAccessory(data);
+                    } else {
+                        this.log('lock is online: %s [%s]', this.displayName(accessory), data.did);
+                        this.accessories[uuid] = new RademacherLockAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                    }
+                } else {
+                    if (accessory === undefined) {
+                        this.addSwitchAccessory(data);
+                    } else {
+                        this.log('switch is online: %s [%s]', this.displayName(accessory), data.did);
+                        this.accessories[uuid] = new RademacherSwitchAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                    }
+                }
+            } else {
+                this.log('lock/switch found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // environment sensor
+        else if (ENVIRONMENT_SENSOR_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_environment_sensor')) {
+                this.addEnvironmentSensorAccessory(accessory, data);
+            } else {
+                this.log('environment sensor found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // sun sensor
+        else if (SUN_SENSOR_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_sun_sensor')) {
+                this.addSunSensorAccessory(accessory, data);
+            } else {
+                this.log('sun sensor found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // unknown
+        else {
+            this.log('Unknown product: %s', data.deviceNumber);
+            if (this.debug) {
+                this.log(String(data));
+            }
         }
     }
 
@@ -224,72 +232,80 @@ export class RademacherHomePilot implements DynamicPlatformPlugin {
         }
         if (body.meters) {
             body.meters.filter(data => this.didFilter(config, data)).forEach((data) => {
-                const uuid = hap.uuid.generate('did' + data.did);
-                const accessory = this.accessories[uuid];
-
-                // smoke alarm
-                if (SMOKE_ALARM_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_smoke_alarm')) {
-                        if (accessory === undefined) {
-                            this.addSmokeAlarmAccessory(data);
-                        } else {
-                            this.log('smoke alarm is online: %s [%s]', this.displayName(accessory), data.did);
-                            this.accessories[uuid] = new RademacherSmokeAlarmAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                        }
-                    } else {
-                        this.log('smoke alarm found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // environment sensor
-                else if (ENVIRONMENT_SENSOR_METERS.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_environment_sensor')) {
-                        this.addEnvironmentSensorAccessory(accessory, data);
-                    } else {
-                        this.log('environment sensor found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // sun sensor
-                else if (SUN_SENSOR_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_sun_sensor')) {
-                        this.addSunSensorAccessory(accessory, data);
-                    } else {
-                        this.log('sun sensor found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // temperature sensor
-                else if (TEMPERATURE_SENSOR_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_temperature_sensor')) {
-                        if (accessory === undefined) {
-                            this.addTemperatureSensorAccessory(data);
-                        } else {
-                            this.log('temperature sensor is online: %s [%s]', data.name, data.did);
-                            this.accessories[uuid] = new RademacherTemperatureSensorAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                        }
-                    } else {
-                        this.log('temperature sensor found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // door/window sensor
-                else if (DOOR_SENSOR_DEVICES.includes(data.deviceNumber!)) {
-                    if (this.flag(config, 'add_door_window_sensor')) {
-                        if (accessory === undefined) {
-                            this.addDoorSensorAccessory(data);
-                        } else {
-                            this.log('door sensor is online: %s [%s]', this.displayName(accessory), data.did);
-                            this.accessories[uuid] = new RademacherDoorSensorAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
-                        }
-                    } else {
-                        this.log('door/window sensor found but not added: %s [%s]', data.name, data.did);
-                    }
-                }
-                // unknown
-                else {
-                    this.log('Unknown product: %s %s %s', data.deviceNumber, data.did, data.name);
-                    this.log(String(data));
+                try {
+                    this.handleSensor(config, data);
+                } catch (err) {
+                    this.log('Error processing device %s [%s]: %s', data.name, data.did, err);
                 }
             });
         } else {
             this.log('No meters found in %s', body);
+        }
+    }
+
+    private handleSensor(config: PlatformConfig, data: HomePilotItem): void {
+        const uuid = hap.uuid.generate('did' + data.did);
+        const accessory = this.accessories[uuid];
+
+        // smoke alarm
+        if (SMOKE_ALARM_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_smoke_alarm')) {
+                if (accessory === undefined) {
+                    this.addSmokeAlarmAccessory(data);
+                } else {
+                    this.log('smoke alarm is online: %s [%s]', this.displayName(accessory), data.did);
+                    this.accessories[uuid] = new RademacherSmokeAlarmAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                }
+            } else {
+                this.log('smoke alarm found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // environment sensor
+        else if (ENVIRONMENT_SENSOR_METERS.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_environment_sensor')) {
+                this.addEnvironmentSensorAccessory(accessory, data);
+            } else {
+                this.log('environment sensor found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // sun sensor
+        else if (SUN_SENSOR_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_sun_sensor')) {
+                this.addSunSensorAccessory(accessory, data);
+            } else {
+                this.log('sun sensor found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // temperature sensor
+        else if (TEMPERATURE_SENSOR_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_temperature_sensor')) {
+                if (accessory === undefined) {
+                    this.addTemperatureSensorAccessory(data);
+                } else {
+                    this.log('temperature sensor is online: %s [%s]', data.name, data.did);
+                    this.accessories[uuid] = new RademacherTemperatureSensorAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                }
+            } else {
+                this.log('temperature sensor found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // door/window sensor
+        else if (DOOR_SENSOR_DEVICES.includes(data.deviceNumber!)) {
+            if (this.flag(config, 'add_door_window_sensor')) {
+                if (accessory === undefined) {
+                    this.addDoorSensorAccessory(data);
+                } else {
+                    this.log('door sensor is online: %s [%s]', this.displayName(accessory), data.did);
+                    this.accessories[uuid] = new RademacherDoorSensorAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                }
+            } else {
+                this.log('door/window sensor found but not added: %s [%s]', data.name, data.did);
+            }
+        }
+        // unknown
+        else {
+            this.log('Unknown product: %s %s %s', data.deviceNumber, data.did, data.name);
+            this.log(String(data));
         }
     }
 
@@ -300,18 +316,22 @@ export class RademacherHomePilot implements DynamicPlatformPlugin {
         }
         if (body.scenes) {
             body.scenes.filter(data => this.didFilter(config, data)).forEach((data) => {
-                if (data.isExecutable === 1) {
-                    const uuid = hap.uuid.generate('sid' + data.sid);
-                    const accessory = this.accessories[uuid];
+                try {
+                    if (data.isExecutable === 1) {
+                        const uuid = hap.uuid.generate('sid' + data.sid);
+                        const accessory = this.accessories[uuid];
 
-                    if (accessory === undefined) {
-                        this.addSceneAccessory(data);
+                        if (accessory === undefined) {
+                            this.addSceneAccessory(data);
+                        } else {
+                            this.log('scene is online: %s [%s]', this.displayName(accessory), data.sid);
+                            this.accessories[uuid] = new RademacherSceneAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                        }
                     } else {
-                        this.log('scene is online: %s [%s]', this.displayName(accessory), data.sid);
-                        this.accessories[uuid] = new RademacherSceneAccessory(this.log, this.debug, this.platformAccessoryOf(accessory), data, this.session);
+                        this.log('Filtered scene: %s %s', data.sid, data.name);
                     }
-                } else {
-                    this.log('Filtered scene: %s %s', data.sid, data.name);
+                } catch (err) {
+                    this.log('Error processing scene %s [%s]: %s', data.name, data.sid, err);
                 }
             });
         } else {


### PR DESCRIPTION
Fixes the crash reported in #166: https://github.com/bombadiltom/homebridge-rademacher-homepilot/issues/166#issuecomment-5309850435

## What changed

Every accessory constructor did `accessory.getService(X)!` — a non-null assertion with no runtime guard. When homebridge restores a cached accessory from its persisted `accessories.json` and that accessory is missing the expected service (e.g. it was cached by an older plugin version, or the HomePilot gateway reassigned the `did` to a different device type), `getService()` returns `undefined` and `.getCharacteristic()` throws:

```
TypeError: Cannot read properties of undefined (reading 'getCharacteristic')
    at new RademacherSmokeAlarmAccessory (...)
```

Because that throw happens inside the axios `.then()` handler for the devices-list GET request, it gets caught by that same promise's `.catch()` and redelivered to the handler as an error (`GET error for path .../v4/devices?devtype=Sensor`, then `Request failed: ...`) — which silently aborts processing of every device that comes after the broken one in that response. That explains why the reporter saw discovery stop partway through their device list.

- Added `RademacherAccessory.getOrAddService()`, which re-adds the missing service instead of crashing, and used it in every accessory constructor
- Wrapped each device's processing in `handleActuators`/`handleSensors`/`handleScenes` in try/catch so a future per-device error can't take the rest of the batch down either

## How it was tested

Ran the built plugin under homebridge (node 22) against a mock HomePilot server. Reproduced the bug by stripping the `SmokeSensor` service from a cached accessory's persisted `accessories.json` on disk (simulating exactly the reported scenario) and restarting: previously this crashed and silently dropped every sensor listed after it; now the service self-heals and every sensor is discovered with no errors. Also re-ran the existing fresh-install and restart smoke tests (all 11 device types) to confirm no regressions.

## Notes for reviewers

This does not address the other symptom in the linked comment — 30s HTTP timeouts against the reporter's older/slower HomePilot gateway. That's a separate, larger change (each sensor accessory currently re-fetches the entire device list on every poll instead of sharing one cached response) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)