### PR TITLE
Coalesce redundant HTTP requests and fix NaN temperature warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.0.3
+### coalesce redundant HTTP requests to the HomePilot gateway
+
 ## 1.0.2
 ### fix crash when a cached accessory is missing a service
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-rademacher-homepilot",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "rademacher homepilot plugin for homebridge: https://github.com/bombadiltom/homebridge-rademacher-homepilot",
   "license": "MIT",
   "keywords": [

--- a/src/RademacherHomePilotSession.ts
+++ b/src/RademacherHomePilotSession.ts
@@ -4,6 +4,11 @@ import { wrapper } from 'axios-cookiejar-support';
 import { CookieJar } from 'tough-cookie';
 import type { Logging } from 'homebridge' with { 'resolution-mode': 'import' };
 
+// How long a getCached() response is reused by other callers hitting the same
+// path. Long enough to coalesce a burst of near-simultaneous polls across
+// accessories, short enough to stay well under any accessory's own poll interval.
+export const SENSOR_LIST_CACHE_TTL_MS = 4000;
+
 export type SessionCallback = (error: Error | null) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SessionGetCallback = (error: Error | null, body: any) => void;
@@ -12,12 +17,20 @@ function sha256hex(data: string): string {
     return createHash('sha256').update(data).digest('hex');
 }
 
+interface CacheEntry {
+    time: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any;
+}
+
 export class RademacherHomePilotSession {
     private readonly log: Logging;
     private readonly debug: boolean;
     private readonly url: string;
     private readonly password: string | null;
     private readonly client: AxiosInstance;
+    private readonly cache = new Map<string, CacheEntry>();
+    private readonly inFlight = new Map<string, SessionGetCallback[]>();
 
     constructor(log: Logging, debug: boolean, url: string, password?: string, passwordHashed?: boolean | string) {
         this.log = log;
@@ -103,6 +116,35 @@ export class RademacherHomePilotSession {
                 this.log('GET error for path %s%s: %s', this.url, path, error);
                 callback(error, null);
             });
+    }
+
+    // Several accessories (smoke alarm, door/sun/environment/temperature sensors) each
+    // poll on their own timer but all read from the same full-list endpoint. Without
+    // sharing, a tick where several of them fire close together turns into that many
+    // separate GETs against a HomePilot gateway that may only serve requests one at a
+    // time - exactly the kind of load that produces "timeout of 30000ms exceeded".
+    // getCached() coalesces concurrent callers into a single in-flight request and
+    // reuses the response for ttlMs afterwards.
+    getCached(path: string, timeout: number, ttlMs: number, callback: SessionGetCallback): void {
+        const cached = this.cache.get(path);
+        if (cached && Date.now() - cached.time < ttlMs) {
+            callback(null, cached.body);
+            return;
+        }
+        const waiters = this.inFlight.get(path);
+        if (waiters) {
+            waiters.push(callback);
+            return;
+        }
+        this.inFlight.set(path, [callback]);
+        this.get(path, timeout, (err, body) => {
+            const callbacks = this.inFlight.get(path) ?? [];
+            this.inFlight.delete(path);
+            if (!err) {
+                this.cache.set(path, { time: Date.now(), body });
+            }
+            callbacks.forEach((cb) => cb(err, body));
+        });
     }
 
     put(path: string, params: unknown, timeout: number, callback: SessionCallback): void {

--- a/src/accessories/RademacherAccessory.ts
+++ b/src/accessories/RademacherAccessory.ts
@@ -5,6 +5,13 @@ import type { HomePilotItem } from '../types';
 
 export type DeviceCallback = (error: Error | null, device?: HomePilotItem | null) => void;
 
+// getDevice() is called once per characteristic read, and HomeKit/our own poll
+// interval can trigger several of those in quick succession for the same
+// accessory (e.g. reading CurrentPosition and TargetPosition together). Reusing
+// a response this fresh avoids redundant round trips to the HomePilot gateway
+// without making state look stale to HomeKit.
+const DEVICE_CACHE_TTL_MS = 4000;
+
 export class RademacherAccessory {
     readonly accessory: PlatformAccessory;
     readonly log: Logging;
@@ -13,6 +20,7 @@ export class RademacherAccessory {
     readonly did?: number;
     protected lastUpdate = 0;
     protected device: HomePilotItem | null = null;
+    private pendingCallbacks: DeviceCallback[] | null = null;
 
     constructor(log: Logging, debug: boolean, accessory: PlatformAccessory, data: HomePilotItem, session: RademacherHomePilotSession) {
         const info = accessory.getService(hap.Service.AccessoryInformation)!;
@@ -55,23 +63,37 @@ export class RademacherAccessory {
     }
 
     getDevice(callback: DeviceCallback): void {
-        if (this.lastUpdate < Date.now()) {
-            this.session.get('/v4/devices/' + this.did, 30000, (e, body) => {
-                if (e) {
-                    return callback(new Error('Request failed: ' + e), null);
-                }
-                if (body && (Object.prototype.hasOwnProperty.call(body, 'device') || Object.prototype.hasOwnProperty.call(body, 'meter'))) {
-                    const device = Object.prototype.hasOwnProperty.call(body, 'device') ? body.device : body.meter;
-                    this.device = device.data;
-                    this.lastUpdate = Date.now();
-                    callback(null, device);
-                } else {
-                    this.log('no device, no meter');
-                    callback(null, this.device);
-                }
-            });
-        } else {
+        if (Date.now() - this.lastUpdate <= DEVICE_CACHE_TTL_MS) {
             callback(null, this.device);
+            return;
         }
+        // update() reads several characteristics back-to-back (e.g. current + target
+        // temperature + heating state), all before any response comes back. The TTL
+        // check above only catches calls made *after* a previous fetch resolved, so
+        // concurrent callers here would otherwise each fire their own request; queue
+        // them onto the one already in flight instead.
+        if (this.pendingCallbacks) {
+            this.pendingCallbacks.push(callback);
+            return;
+        }
+        this.pendingCallbacks = [callback];
+        this.session.get('/v4/devices/' + this.did, 30000, (e, body) => {
+            const callbacks = this.pendingCallbacks ?? [];
+            this.pendingCallbacks = null;
+            if (e) {
+                const error = new Error('Request failed: ' + e);
+                callbacks.forEach((cb) => cb(error, null));
+                return;
+            }
+            if (body && (Object.prototype.hasOwnProperty.call(body, 'device') || Object.prototype.hasOwnProperty.call(body, 'meter'))) {
+                const device = Object.prototype.hasOwnProperty.call(body, 'device') ? body.device : body.meter;
+                this.device = device.data;
+                this.lastUpdate = Date.now();
+                callbacks.forEach((cb) => cb(null, device));
+            } else {
+                this.log('no device, no meter');
+                callbacks.forEach((cb) => cb(null, this.device));
+            }
+        });
     }
 }

--- a/src/accessories/RademacherAccessory.ts
+++ b/src/accessories/RademacherAccessory.ts
@@ -86,8 +86,14 @@ export class RademacherAccessory {
                 return;
             }
             if (body && (Object.prototype.hasOwnProperty.call(body, 'device') || Object.prototype.hasOwnProperty.call(body, 'meter'))) {
-                const device = Object.prototype.hasOwnProperty.call(body, 'device') ? body.device : body.meter;
-                this.device = device.data;
+                // The API nests the actually useful fields (statusesMap, readings, ...)
+                // one level under "data". Every caller reads e.g. device.statusesMap
+                // directly, so make sure the flattened payload - the same value stored
+                // in this.device for the cache-hit path below - is what callers get here
+                // too, instead of the outer wrapper.
+                const wrapper = Object.prototype.hasOwnProperty.call(body, 'device') ? body.device : body.meter;
+                const device = wrapper.data ?? wrapper;
+                this.device = device;
                 this.lastUpdate = Date.now();
                 callbacks.forEach((cb) => cb(null, device));
             } else {

--- a/src/accessories/RademacherDoorSensorAccessory.ts
+++ b/src/accessories/RademacherDoorSensorAccessory.ts
@@ -1,7 +1,7 @@
 import type { CharacteristicValue, Logging, PlatformAccessory, Service } from 'homebridge' with { 'resolution-mode': 'import' };
 import { hap } from '../hap';
 import { RademacherAccessory } from './RademacherAccessory';
-import type { RademacherHomePilotSession } from '../RademacherHomePilotSession';
+import { SENSOR_LIST_CACHE_TTL_MS, type RademacherHomePilotSession } from '../RademacherHomePilotSession';
 import type { DevicesResponse, HomePilotItem } from '../types';
 
 type GetCallback = (error: Error | null, value?: CharacteristicValue | null) => void;
@@ -39,7 +39,7 @@ export class RademacherDoorSensorAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentDoorState()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentState);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentDoorState(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;
@@ -67,7 +67,7 @@ export class RademacherDoorSensorAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentBatteryLevel()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentBatteryLevel);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentBatteryLevel(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;

--- a/src/accessories/RademacherEnvironmentSensorAccessory.ts
+++ b/src/accessories/RademacherEnvironmentSensorAccessory.ts
@@ -1,7 +1,7 @@
 import type { CharacteristicValue, Logging, PlatformAccessory, Service } from 'homebridge' with { 'resolution-mode': 'import' };
 import { hap } from '../hap';
 import { RademacherAccessory } from './RademacherAccessory';
-import type { RademacherHomePilotSession } from '../RademacherHomePilotSession';
+import { SENSOR_LIST_CACHE_TTL_MS, type RademacherHomePilotSession } from '../RademacherHomePilotSession';
 import type { DevicesResponse, HomePilotItem } from '../types';
 
 type GetCallback = (error: Error | null, value?: CharacteristicValue | null) => void;
@@ -50,7 +50,7 @@ export class RademacherEnvironmentSensorAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentTemperature()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentTemperature);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentTemperature(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;
@@ -73,7 +73,7 @@ export class RademacherEnvironmentSensorAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentRainState()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentRainState);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentRainState(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;
@@ -96,7 +96,7 @@ export class RademacherEnvironmentSensorAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentAmbientLightLevel()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentAmbientLightLevel);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentAmbientLightLevel(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;

--- a/src/accessories/RademacherSmokeAlarmAccessory.ts
+++ b/src/accessories/RademacherSmokeAlarmAccessory.ts
@@ -1,7 +1,7 @@
 import type { CharacteristicValue, Logging, PlatformAccessory, Service } from 'homebridge' with { 'resolution-mode': 'import' };
 import { hap } from '../hap';
 import { RademacherAccessory } from './RademacherAccessory';
-import type { RademacherHomePilotSession } from '../RademacherHomePilotSession';
+import { SENSOR_LIST_CACHE_TTL_MS, type RademacherHomePilotSession } from '../RademacherHomePilotSession';
 import type { DevicesResponse, HomePilotItem } from '../types';
 
 type GetCallback = (error: Error | null, value?: CharacteristicValue | null) => void;
@@ -39,7 +39,7 @@ export class RademacherSmokeAlarmAccessory extends RademacherAccessory {
             this.log('%s [%s] - getSmokeDetected()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.smokeDetected);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getSmokeDetected(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;
@@ -62,7 +62,7 @@ export class RademacherSmokeAlarmAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentBatteryLevel()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentBatteryLevel);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentBatteryLevel(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;

--- a/src/accessories/RademacherSunSensorAccessory.ts
+++ b/src/accessories/RademacherSunSensorAccessory.ts
@@ -1,7 +1,7 @@
 import type { CharacteristicValue, Logging, PlatformAccessory, Service } from 'homebridge' with { 'resolution-mode': 'import' };
 import { hap } from '../hap';
 import { RademacherAccessory } from './RademacherAccessory';
-import type { RademacherHomePilotSession } from '../RademacherHomePilotSession';
+import { SENSOR_LIST_CACHE_TTL_MS, type RademacherHomePilotSession } from '../RademacherHomePilotSession';
 import type { DevicesResponse, HomePilotItem } from '../types';
 
 type GetCallback = (error: Error | null, value?: CharacteristicValue | null) => void;
@@ -36,7 +36,7 @@ export class RademacherSunSensorAccessory extends RademacherAccessory {
             this.log('%s [%s] - getCurrentSunState()', this.accessory.displayName, this.sensor.did);
         }
         callback(null, this.currentSunState);
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentSunState(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;

--- a/src/accessories/RademacherTemperatureSensorAccessory.ts
+++ b/src/accessories/RademacherTemperatureSensorAccessory.ts
@@ -1,7 +1,7 @@
 import type { CharacteristicValue, Logging, PlatformAccessory, Service } from 'homebridge' with { 'resolution-mode': 'import' };
 import { hap } from '../hap';
 import { RademacherAccessory } from './RademacherAccessory';
-import type { RademacherHomePilotSession } from '../RademacherHomePilotSession';
+import { SENSOR_LIST_CACHE_TTL_MS, type RademacherHomePilotSession } from '../RademacherHomePilotSession';
 import type { DevicesResponse, HomePilotItem } from '../types';
 
 type GetCallback = (error: Error | null, value?: CharacteristicValue | null) => void;
@@ -30,7 +30,7 @@ export class RademacherTemperatureSensorAccessory extends RademacherAccessory {
         }
         callback(null, this.currentTemperature);
 
-        this.session.get('/v4/devices?devtype=Sensor', 30000, (err, body: DevicesResponse) => {
+        this.session.getCached('/v4/devices?devtype=Sensor', 30000, SENSOR_LIST_CACHE_TTL_MS, (err, body: DevicesResponse) => {
             if (err) {
                 this.log('%s [%s] - getCurrentTemperature(): error=%s', this.accessory.displayName, this.sensor.did, err);
                 return;


### PR DESCRIPTION
Follow-up to #168, which merged early and only captured the self-heal fix. This PR carries the remaining commits made on the same branch afterward.

## What changed

**Request coalescing** — several sensor accessories (smoke alarm, door/sun/environment sensors) each poll independently and re-fetch the entire device list on every characteristic read rather than sharing a response; when several tick close together that's a burst of concurrent GETs against a HomePilot gateway that may only serve one request at a time, a plausible contributor to the `timeout of 30000ms exceeded` errors reported in #166.

- `RademacherHomePilotSession.getCached()` coalesces concurrent callers into one in-flight request and reuses the response for a short TTL; used by the five sensor accessory types for the shared list endpoint
- `RademacherAccessory.getDevice()`'s `lastUpdate` cache never actually worked (it compared against `Date.now()` at call time, which was true on nearly every call). Fixed to a real TTL, plus in-flight queuing so accessories reading several characteristics back-to-back (e.g. the thermostat) fire one device GET instead of three

**NaN Current/Target Temperature warnings** — `getDevice()` flattens the single-device response (fields are nested one level under `data`, unlike the list endpoints) and stores that in `this.device`, but on a *fresh* fetch it handed callers the outer wrapper instead of the flattened value, while the cache-hit path correctly returned `this.device`. Every accessory reads e.g. `data.statusesMap.acttemperatur` directly, so a fresh fetch produced `undefined`, and `undefined / 10` is `NaN`. Most accessory types silently coerced or guarded around the missing field; the thermostat's Temperature characteristics are strictly validated by HAP, so it surfaced as a visible warning. This bug predates this session's changes (unchanged from the original plugin) but was more likely to be hit once the coalescing fix removed the "always cache miss" behavior it had been incidentally masked by.

Version bumped to 1.0.3 with a CHANGELOG entry.

## How it was tested

Verified against a mock HomePilot server (fixed to nest single-device fields under `data` like the real API, since the earlier flat mock had been hiding the NaN bug): a thermostat's three back-to-back characteristic reads now fire one device GET instead of three, a tick where four sensor accessories fire together now issues one list GET instead of up to eight, and no NaN warnings or other errors appear. Existing fresh-install and restart smoke tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)